### PR TITLE
Fix/accessible

### DIFF
--- a/Models/Common/Ink.cs
+++ b/Models/Common/Ink.cs
@@ -19,7 +19,11 @@ public class Ink
 		set
 		{
 			if (!value.HasInk())
+			{
+				// Would be nice to handle this better one day.
 				Console.WriteLine("Ink cannot be empty or whitespace; rejecting change.");
+				return;
+			}
 
 			this.value = value.Trim();
 		}

--- a/Models/Common/Ink.cs
+++ b/Models/Common/Ink.cs
@@ -16,7 +16,7 @@ public class Ink
 		set
 		{
 			if (!value.HasInk())
-				throw new ArgumentException(Value, nameof(Value));
+				throw new ArgumentException("Ink cannot be empty or whitespace", nameof(Value));
 
 			this.value = value.Trim();
 		}

--- a/Models/Common/Ink.cs
+++ b/Models/Common/Ink.cs
@@ -6,6 +6,9 @@ public class Ink
 
 	public Ink(string value)
 	{
+		if (!value.HasInk())
+			throw new ArgumentException("Ink cannot be empty or whitespace", nameof(value));
+
 		Value = value;
 		this.value = Value; // C# nullability silliness
 	}
@@ -16,7 +19,7 @@ public class Ink
 		set
 		{
 			if (!value.HasInk())
-				throw new ArgumentException("Ink cannot be empty or whitespace", nameof(Value));
+				Console.WriteLine("Ink cannot be empty or whitespace; rejecting change.");
 
 			this.value = value.Trim();
 		}

--- a/Models/Settings/GameSetting.cs
+++ b/Models/Settings/GameSetting.cs
@@ -1,4 +1,6 @@
-﻿namespace Models.Settings;
+﻿using Newtonsoft.Json;
+
+namespace Models.Settings;
 
 public record GameSetting
 (
@@ -26,7 +28,12 @@ public record PlaybookSetting
 	DefaultActionPointSetting[] DefaultActionPoints,
 	string ExperienceCondition,
 	string AliasSynonym = Constants.DefaultNames.Alias
-);
+)
+{
+	[JsonConstructor] // Annoying workaround for Newtonsoft
+	public PlaybookSetting(string Name, string Hook, SpecialAbilitySetting[] SpecialAbilities, RolodexSetting Rolodex, GearItemSetting[] Items, DefaultActionPointSetting[] DefaultActionPoints, string ExperienceCondition)
+	: this(Name, Hook, SpecialAbilities, Rolodex, Items, DefaultActionPoints, ExperienceCondition, Constants.DefaultNames.Alias) { }
+}
 
 public record SpecialAbilitySetting
 (

--- a/Persistence/Json/ServerFileReader.cs
+++ b/Persistence/Json/ServerFileReader.cs
@@ -35,9 +35,9 @@ public class ServerFileReader : IFileReader
 			?? throw new FileNotFoundException($"games.json is missing from {this.directoryPath}");
 	}
 
-	public async Task<string> ReadFile(string fileName)
+	public async Task<string> ReadFile(string fileStem)
 	{
-		var path = Path.Combine(this.directoryPath, fileName);
+		var path = Path.Combine(this.directoryPath, fileStem + ".json");
 
 		var text = await File.ReadAllTextAsync(path);
 

--- a/UI/Components/CharacterSheet/SheetAbilitiesCard.razor
+++ b/UI/Components/CharacterSheet/SheetAbilitiesCard.razor
@@ -42,7 +42,7 @@
 
 	Playbook Playbook => Character.Playbook;
 
-	public bool IsFixMode { get; set; }
+	public bool IsFixMode { get; set; } = false;
 
 	IReadOnlyCollection<PlaybookSpecialAbility> KnownAbilities =>
 		Playbook.Abilities;

--- a/UI/Components/CharacterSheet/SheetAbilitiesCard.razor
+++ b/UI/Components/CharacterSheet/SheetAbilitiesCard.razor
@@ -9,10 +9,10 @@
 
 <SheetCard @bind-IsFixMode="IsFixMode" Header="@Playbook.Name.ToString()">
 	<MudStack>
-		<MudRating @bind-SelectedValue="Playbook.Experience.Points" MaxValue="Playbook.Experience.MaxPoints" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+		<MudRating @bind-SelectedValue="Playbook.Experience.Points" MaxValue="Playbook.Experience.MaxPoints" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" aria-label="Playbook experience points" />
 		<MudGrid>
 			<MudItem xs="12" sm="9">
-				<MudSelect @bind-Value="SelectedAbility" ToStringFunc="@converter">
+				<MudSelect @bind-Value="SelectedAbility" ToStringFunc="@converter" aria-label="Select playbook ability to learn">
 					@foreach (var ability in LearnableAbilities)
 					{
 						<MudSelectItem Value="ability" />
@@ -20,7 +20,7 @@
 				</MudSelect>
 			</MudItem>
 			<MudItem xs="12" sm="3">
-				<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="CannotAddAbility" OnClick="AddAbility" Style="@UI.Constants.Buttons.ButtonDimensionStyle">Ability</MudButton>
+				<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="CannotAddAbility" OnClick="AddAbility" Style="@UI.Constants.Buttons.ButtonDimensionStyle" aria-label="Learn ability">Ability</MudButton>
 			</MudItem>
 		</MudGrid>
 		<MudStack>

--- a/UI/Components/CharacterSheet/SheetAbility.razor
+++ b/UI/Components/CharacterSheet/SheetAbility.razor
@@ -8,8 +8,8 @@
 
 @if (IsFixMode)
 {
-	<MudButton Size="Size.Medium" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="(e => RemoveAbility(Ability))">@Ability.LearnedTimesDisplayName()</MudButton>
-	<MudTextField @bind-Value:get="@Ability.Description" @bind-Value:set="OverwriteDescription" Lines="5" Variant="Variant.Outlined" Label="@EditAbilityLabel" />
+	<MudButton Size="Size.Medium" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="(e => RemoveAbility(Ability))" aria-label="@RemoveAbilityLabel">@Ability.LearnedTimesDisplayName()</MudButton>
+	<MudTextField @bind-Value:get="@Ability.Description" @bind-Value:set="OverwriteDescription" Lines="5" Variant="Variant.Outlined" Label="@EditAbilityLabel" id="@TextFieldId" />
 }
 else
 {
@@ -18,34 +18,41 @@ else
 }
 @code
 {
-		[Parameter, EditorRequired]
-		public bool IsFixMode { get; set; } = false;
+	[Parameter, EditorRequired]
+	public bool IsFixMode { get; set; } = false;
 
-		[Parameter, EditorRequired]
-		public Character? Character { get; set; }
+	[Parameter, EditorRequired]
+	public Character? Character { get; set; }
 
-		[Parameter, EditorRequired]
-		public PlaybookSpecialAbility? Ability { get; set; }
+	[Parameter, EditorRequired]
+	public PlaybookSpecialAbility? Ability { get; set; }
 
-		Playbook? Playbook => Character?.Playbook;
+	Playbook? Playbook => Character?.Playbook;
 
-		void OverwriteDescription(string description) 
-		{
-			var hadSpecialArmor = Character!.HasSpecialArmor;
-			var changed = Ability!.OverwriteDescription(description);
+	void OverwriteDescription(string description)
+	{
+		var hadSpecialArmor = Character!.HasSpecialArmor;
+		var changed = Ability!.OverwriteDescription(description);
 
-			if (!changed) 
-				return;
+		if (!changed)
+			return;
 
-			if (hadSpecialArmor != Character!.HasSpecialArmor)
-				SheetJank.NotifyAbilitiesChanged();
-		}
-
-		void RemoveAbility(PlaybookSpecialAbility ability)
-		{
-			Playbook!.RemoveAbility(ability);
+		if (hadSpecialArmor != Character!.HasSpecialArmor)
 			SheetJank.NotifyAbilitiesChanged();
-		}
+	}
 
-		string EditAbilityLabel => $"Edit {Ability!.Name} Description";
+	void RemoveAbility(PlaybookSpecialAbility ability)
+	{
+		Playbook!.RemoveAbility(ability);
+		SheetJank.NotifyAbilitiesChanged();
+	}
+
+	string EditAbilityLabel =>
+		$"Edit {Ability!.Name} Description";
+
+	string RemoveAbilityLabel =>
+		$"Unlearn {Ability!.Name}";
+
+	string TextFieldId =>
+		$"text-field-{Ability!.Name}";
 }

--- a/UI/Components/CharacterSheet/SheetDossierCard.razor
+++ b/UI/Components/CharacterSheet/SheetDossierCard.razor
@@ -2,20 +2,20 @@
 @using UI.Conveniences
 
 <SheetCard @bind-IsFixMode="IsFixMode" Header="Dossier">
+	<MudStack>
 		<MudGrid>
 			<MudItem xs="8">
-				<MudTextField @bind-Value="Dossier.Name" HelperText="Name" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" />
+				<MudTextField @bind-Value="Dossier.Name" id="Dossier.Name" Label="Name" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Variant="Variant" />
 			</MudItem>
 			<MudItem xs="4">
-				<MudTextField @bind-Value="Dossier.Alias" HelperText="@AliasSynonym" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" />
+				<MudTextField @bind-Value="Dossier.Alias" id="Dossier.Alias" Label="@AliasSynonym" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Variant="Variant" />
 			</MudItem>
 		</MudGrid>
-		<MudStack>
-			<MudTextField @bind-Value="Dossier.Background.Description" HelperText="@BackgroundHelperText" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" />
-			<MudTextField @bind-Value="Dossier.Heritage.Description" HelperText="@HeritageHelperText" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" />
-			<MudTextField @bind-Value="Dossier.Vice.Description" HelperText="@ViceHelperText" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" />
-			<MudTextField @bind-Value="Dossier.Look" HelperText="Look" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" />
-		</MudStack>
+		<MudTextField @bind-Value="Dossier.Background.Description" id="Dossier.Background.Description" Label="@BackgroundLabel" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" Variant="Variant" />
+		<MudTextField @bind-Value="Dossier.Heritage.Description" id="Dossier.Heritage.Description" Label="@HeritageLabel" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" Variant="Variant" />
+		<MudTextField @bind-Value="Dossier.Vice.Description" id="Dossier.Vice.Description" Label="@ViceLabel" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" Variant="Variant" />
+		<MudTextField @bind-Value="Dossier.Look" id="Dossier.Look" Label="Look" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" Lines="3" Variant="Variant" />
+	</MudStack>
 </SheetCard>
 
 @code
@@ -28,12 +28,16 @@
 
 	bool IsFixMode { get; set; } = false;
 
-	string BackgroundHelperText =>
+	string BackgroundLabel =>
 		$"Background: {Dossier.Background.Name}";
 
-	string HeritageHelperText =>
+	string HeritageLabel =>
 		$"Heritage: {Dossier.Heritage.Name}";
 
-	string ViceHelperText =>
+	string ViceLabel =>
 		$"Vice: {Dossier.Vice.Name}";
+
+	Variant Variant =>
+		IsFixMode ? Variant.Outlined
+		: Variant.Text;
 }

--- a/UI/Components/CharacterSheet/SheetExistingHarm.razor
+++ b/UI/Components/CharacterSheet/SheetExistingHarm.razor
@@ -10,7 +10,7 @@
 	{
 		@foreach (var description in HarmDescriptions)
 		{
-			<MudButton Size="Size.Small" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(e => RemoveHarm(description))">@description</MudButton>
+			<MudButton Size="Size.Small" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(e => RemoveHarm(description))" aria-label="@AriaLabel(description)">@description</MudButton>
 		}
 	}
 	else
@@ -47,4 +47,7 @@
 	{
 		Harm.RemoveHarm(description, Intensity);
 	}
+
+	string AriaLabel(string description) =>
+		"Remove " + description;
 }

--- a/UI/Components/CharacterSheet/SheetFundCard.razor
+++ b/UI/Components/CharacterSheet/SheetFundCard.razor
@@ -8,11 +8,11 @@
 		<MudItem xs="12">
 			<MudStack Spacing="1">
 				<MudText Typo="Typo.caption">Satchel: </MudText>
-				<MudRating @bind-SelectedValue="Fund.Satchel.Coins" ReadOnly="!IsFixMode" MaxValue="Fund.Satchel.MaxCoins" FullIcon="@Icons.Material.Filled.Paid" EmptyIcon="@Icons.Material.Outlined.Paid" Color="Color.Primary" aria-label="@SatchelLabel" />
+				<MudRating @bind-SelectedValue="Fund.Satchel.Coins" ReadOnly="!IsFixMode" MaxValue="Fund.Satchel.MaxCoins" FullIcon="@Icons.Material.Filled.Paid" EmptyIcon="@Icons.Material.Outlined.Paid" Color="Color.Primary" aria-label="@SatchelLabel" id="fund-satchel-rating" />
 			</MudStack>
 		</MudItem>
 		<MudItem xs="12" lg="6">
-			<MudNumericField @bind-Value="Fund.Stash.Stash" Label="Stash" Disabled="!IsFixMode" Min="Fund.Stash.MinCoins" Max="Fund.Stash.MaxCoins" />
+			<MudNumericField @bind-Value="Fund.Stash.Stash" Label="Stash" Disabled="!IsFixMode" Min="Fund.Stash.MinCoins" Max="Fund.Stash.MaxCoins" id="fund-stash-coin" />
 		</MudItem>
 		<MudItem xs="6" lg="3">
 			<MudText Typo="Typo.caption">Lifestyle:</MudText>
@@ -23,7 +23,7 @@
 			<MudText Typo="Typo.body1">@Fund.Stash.Rating</MudText>
 		</MudItem>
 		<MudItem xs="12" lg="6">
-			<MudNumericField @bind-Value="CoinChangeInput" Label="@CoinChangeInputLabel" Min="Fund.MinCoins" Max="InputMaximum" />
+			<MudNumericField @bind-Value="CoinChangeInput" Label="@CoinChangeInputLabel" Min="Fund.MinCoins" Max="InputMaximum" id="fund-coin-change" />
 		</MudItem>
 		<MudItem xs="12" lg="6">
 			<MudButtonGroup Size="Size.Medium" Variant="Variant.Outlined" Style="width: 100%">

--- a/UI/Components/CharacterSheet/SheetFundCard.razor
+++ b/UI/Components/CharacterSheet/SheetFundCard.razor
@@ -8,7 +8,7 @@
 		<MudItem xs="12">
 			<MudStack Spacing="1">
 				<MudText Typo="Typo.caption">Satchel: </MudText>
-				<MudRating @bind-SelectedValue="Fund.Satchel.Coins" ReadOnly="!IsFixMode" MaxValue="Fund.Satchel.MaxCoins" FullIcon="@Icons.Material.Filled.Paid" EmptyIcon="@Icons.Material.Outlined.Paid" Color="Color.Primary" />
+				<MudRating @bind-SelectedValue="Fund.Satchel.Coins" ReadOnly="!IsFixMode" MaxValue="Fund.Satchel.MaxCoins" FullIcon="@Icons.Material.Filled.Paid" EmptyIcon="@Icons.Material.Outlined.Paid" Color="Color.Primary" aria-label="@SatchelLabel" />
 			</MudStack>
 		</MudItem>
 		<MudItem xs="12" lg="6">
@@ -55,4 +55,6 @@
 	bool SpendButtonEnabled => Fund.CanSpend(CoinChangeInput) && CoinChangeInput > 0;
 
 	string ButtonStyle { get; } = Constants.Buttons.ButtonDimensionStyle + "width: 50%;";
+
+	string SatchelLabel => $"{CoinSynonym} on hand";
 }

--- a/UI/Components/CharacterSheet/SheetGearCard.razor
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor
@@ -13,13 +13,13 @@
 				<MudRadioGroup @bind-SelectedOption="Gear.Commitment.Commitment">
 					<MudRadio Option="LoadCommitmentOption.None" Disabled="!RadioCommitmentsEnabled">@LoadCommitmentOption.None</MudRadio>
 					<MudRadio Option="LoadCommitmentOption.Light" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Light) @LoadCommitmentOption.Light</MudRadio>
-						<MudRadio Option="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Normal) @LoadCommitmentOption.Normal</MudRadio>
-						<MudRadio Option="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Heavy) @LoadCommitmentOption.Heavy</MudRadio>
-						<MudRadio Option="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Encumbered) @LoadCommitmentOption.Encumbered</MudRadio>
-					</MudRadioGroup>
-				</MudItem>
-				<MudItem xs="12" sm="4">
-					@if (CommitmentLocked)
+					<MudRadio Option="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Normal) @LoadCommitmentOption.Normal</MudRadio>
+					<MudRadio Option="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Heavy) @LoadCommitmentOption.Heavy</MudRadio>
+					<MudRadio Option="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Encumbered) @LoadCommitmentOption.Encumbered</MudRadio>
+				</MudRadioGroup>
+			</MudItem>
+			<MudItem xs="12" sm="4">
+				@if (CommitmentLocked)
 				{
 					<MudButton FullWidth="true" Variant="Variant.Outlined" OnClick="() => { ClearCommitments(); CommitmentLocked = false; }">Reset</MudButton>
 				}
@@ -123,7 +123,8 @@
 		set
 		{
 			commitmentItemRenderer = value ? (i) => RenderCommitmentButtons(i)
-		: (i) => RenderCommitmentText(i);
+				: (i) => RenderCommitmentText(i);
+
 			isFixMode = value;
 		}
 	}

--- a/UI/Components/CharacterSheet/SheetGearCard.razor
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor
@@ -68,7 +68,7 @@
 					<MudTextField @bind-Value=addableItem.Name Label="Name" />
 				</MudItem>
 				<MudItem xs="12" sm="4">
-					<MudButton OnClick="AddItem" Disabled="!IsAddItemEnabled" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.AddCircle">Add</MudButton>
+					<MudButton OnClick="AddItem" Disabled="!IsAddItemEnabled" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.AddCircle" aria-label="Add new item">Add</MudButton>
 				</MudItem>
 			</MudGrid>
 		}
@@ -139,11 +139,13 @@
 
 	RenderFragment RenderCommitmentText(GearItem item) => @<MudText>@item.Name (@item.Bulk)</MudText>;
 
-	RenderFragment RenderCommitmentButtons(GearItem item) => @<MudButton Style="margin: 5px; max-width: 400px" FullWidth="false" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.RemoveCircle" OnClick="() => UncommitGear(item)">@item.Name (@item.Bulk)</MudButton>;
+	RenderFragment RenderCommitmentButtons(GearItem item) => @<MudButton Style="margin: 5px; max-width: 400px" FullWidth="false" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.RemoveCircle" OnClick="() => UncommitGear(item)" aria-label="@CommitmentButtonLabel(item)">@item.Name (@item.Bulk)</MudButton>;
 
 	NewItem addableItem = new();
 
 	bool IsAddItemEnabled => addableItem.Name.HasInk() && Gear.CanAddAvailableItem(addableItem.Name);
+
+	string CommitmentButtonLabel(GearItem item) => $"Uncommit {item.Name} ({item.Bulk})";
 
 	void AddItem()
 	{

--- a/UI/Components/CharacterSheet/SheetGearCard.razor
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor
@@ -13,13 +13,13 @@
 				<MudRadioGroup @bind-SelectedOption="Gear.Commitment.Commitment">
 					<MudRadio Option="LoadCommitmentOption.None" Disabled="!RadioCommitmentsEnabled">@LoadCommitmentOption.None</MudRadio>
 					<MudRadio Option="LoadCommitmentOption.Light" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Light) @LoadCommitmentOption.Light</MudRadio>
-					<MudRadio Option="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Normal) @LoadCommitmentOption.Normal</MudRadio>
-					<MudRadio Option="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Heavy) @LoadCommitmentOption.Heavy</MudRadio>
-					<MudRadio Option="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Encumbered) @LoadCommitmentOption.Encumbered</MudRadio>
-				</MudRadioGroup>
-			</MudItem>
-			<MudItem xs="12" sm="4">
-				@if (CommitmentLocked)
+						<MudRadio Option="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Normal) @LoadCommitmentOption.Normal</MudRadio>
+						<MudRadio Option="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Heavy) @LoadCommitmentOption.Heavy</MudRadio>
+						<MudRadio Option="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Encumbered) @LoadCommitmentOption.Encumbered</MudRadio>
+					</MudRadioGroup>
+				</MudItem>
+				<MudItem xs="12" sm="4">
+					@if (CommitmentLocked)
 				{
 					<MudButton FullWidth="true" Variant="Variant.Outlined" OnClick="() => { ClearCommitments(); CommitmentLocked = false; }">Reset</MudButton>
 				}
@@ -47,7 +47,7 @@
 		<MudContainer>
 			@foreach (var item in Gear.UncommittedGear)
 			{
-				@if(!IsFixMode)
+				@if (!IsFixMode)
 				{
 					<MudButton Style="margin: 5px;" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.AddCircle" Disabled="!Character.CanCommitGear(item) || !CommitmentLocked" OnClick="() => CommitGear(item)">@item.Display()</MudButton>
 				}
@@ -61,11 +61,11 @@
 		{
 			<MudText Typo="Typo.h6">Add Item</MudText>
 			<MudGrid>
-				<MudItem xs="4" sm="2">
-					<MudTextField @bind-Value=addableItem.Bulk Label="@BulkSynonym" id="gear-add-item-bulk" />
-				</MudItem>
 				<MudItem xs="8" sm="6">
 					<MudTextField @bind-Value=addableItem.Name Label="Name" id="gear-add-item-name" />
+				</MudItem>
+				<MudItem xs="4" sm="2">
+					<MudTextField @bind-Value=addableItem.Bulk Label="@BulkSynonym" id="gear-add-item-bulk" />
 				</MudItem>
 				<MudItem xs="12" sm="4">
 					<MudButton OnClick="AddItem" Disabled="!IsAddItemEnabled" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.AddCircle" aria-label="Add new item">Add</MudButton>
@@ -123,7 +123,7 @@
 		set
 		{
 			commitmentItemRenderer = value ? (i) => RenderCommitmentButtons(i)
-	: (i) => RenderCommitmentText(i);
+		: (i) => RenderCommitmentText(i);
 			isFixMode = value;
 		}
 	}

--- a/UI/Components/CharacterSheet/SheetGearCard.razor
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor
@@ -62,10 +62,10 @@
 			<MudText Typo="Typo.h6">Add Item</MudText>
 			<MudGrid>
 				<MudItem xs="4" sm="2">
-					<MudTextField @bind-Value=addableItem.Bulk Label="@BulkSynonym" />
+					<MudTextField @bind-Value=addableItem.Bulk Label="@BulkSynonym" id="gear-add-item-bulk" />
 				</MudItem>
 				<MudItem xs="8" sm="6">
-					<MudTextField @bind-Value=addableItem.Name Label="Name" />
+					<MudTextField @bind-Value=addableItem.Name Label="Name" id="gear-add-item-name" />
 				</MudItem>
 				<MudItem xs="12" sm="4">
 					<MudButton OnClick="AddItem" Disabled="!IsAddItemEnabled" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.AddCircle" aria-label="Add new item">Add</MudButton>

--- a/UI/Components/CharacterSheet/SheetMonitorCard.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorCard.razor
@@ -9,7 +9,7 @@
 <SheetCard @bind-IsFixMode="IsFixMode" Header="Health">
 	<MudGrid>
 		<MudItem xs="12">
-			<MudSlider @bind-Value="@Monitor.Stress.CurrentStress" Size="Size.Medium" TickMarks="true" TickMarkLabels="@StressLabels" Max="@MonitorStress.MaxStress" Variant="@Variant.Filled" Color="@StressColor">
+			<MudSlider @bind-Value="@Monitor.Stress.CurrentStress" Size="Size.Medium" TickMarks="true" TickMarkLabels="@StressLabels" Max="@MonitorStress.MaxStress" Variant="@Variant.Filled" Color="@StressColor" aria-label="Stress slider">
 				Stress
 			</MudSlider>
 		</MudItem>

--- a/UI/Components/CharacterSheet/SheetMonitorHarm.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorHarm.razor
@@ -5,9 +5,9 @@
 @implements IDisposable
 
 <MudStack>
-	<MudTextField @bind-Value="HarmDescription" Placeholder="@HarmPlaceholder" Clearable="true" Immediate="true" />
+	<MudTextField @bind-Value="HarmDescription" Placeholder="@HarmPlaceholder" Clearable="true" Immediate="true" aria-label="Describe harm" />
 	<MudStack Row="true" Class="flex-grow-1">
-		<MudSelect @bind-Value="Intensity" Text="@Intensity?.ToString()">
+		<MudSelect @bind-Value="Intensity" Text="@Intensity?.ToString()" aria-label="Harm intensity">
 			@foreach (var intensity in Harm.AvailableIntensities)
 			{
 				<MudSelectItem T="HarmIntensity?" Value="intensity">
@@ -15,7 +15,7 @@
 				</MudSelectItem>
 			}
 		</MudSelect>
-		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="!CanAddHarm" OnClick="AddHarm" Style="@Constants.Buttons.ButtonDimensionStyle">Harm</MudButton>
+		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="!CanAddHarm" OnClick="AddHarm" Style="@Constants.Buttons.ButtonDimensionStyle" aria-label="Add harm">Harm</MudButton>
 	</MudStack>
 	<SheetExistingHarm IsFixMode="IsFixMode" Harm="Harm" Intensity="HarmIntensity.Fatal" />
 	<SheetExistingHarm IsFixMode="IsFixMode" Harm="Harm" Intensity="HarmIntensity.Severe" />

--- a/UI/Components/CharacterSheet/SheetMonitorHarm.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorHarm.razor
@@ -5,8 +5,8 @@
 @implements IDisposable
 
 <MudStack>
+	<MudTextField @bind-Value="HarmDescription" Placeholder="@HarmPlaceholder" Clearable="true" Immediate="true" />
 	<MudStack Row="true" Class="flex-grow-1">
-		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="!CanAddHarm" OnClick="AddHarm" Style="@Constants.Buttons.ButtonDimensionStyle">Harm</MudButton>
 		<MudSelect @bind-Value="Intensity" Text="@Intensity?.ToString()">
 			@foreach (var intensity in Harm.AvailableIntensities)
 			{
@@ -15,8 +15,8 @@
 				</MudSelectItem>
 			}
 		</MudSelect>
+		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="!CanAddHarm" OnClick="AddHarm" Style="@Constants.Buttons.ButtonDimensionStyle">Harm</MudButton>
 	</MudStack>
-	<MudTextField @bind-Value="HarmDescription" Placeholder="@HarmPlaceholder" Clearable="true" Immediate="true" />
 	<SheetExistingHarm IsFixMode="IsFixMode" Harm="Harm" Intensity="HarmIntensity.Fatal" />
 	<SheetExistingHarm IsFixMode="IsFixMode" Harm="Harm" Intensity="HarmIntensity.Severe" />
 	<SheetExistingHarm IsFixMode="IsFixMode" Harm="Harm" Intensity="HarmIntensity.Moderate" />

--- a/UI/Components/CharacterSheet/SheetMonitorRecovery.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorRecovery.razor
@@ -8,15 +8,15 @@
 		<MudText Typo="Typo.caption">Healing Project:</MudText>
 		@if (IsFixMode)
 		{
-			<MudRating @bind-SelectedValue="HealingClock.Time" MaxValue="MaxRecovery" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" Color="Color.Secondary" />
+			<MudRating @bind-SelectedValue="HealingClock.Time" MaxValue="MaxRecovery" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" Color="Color.Secondary" aria-label="Set recovery progress"/>
 		}
 		else
 		{
-			<MudRating SelectedValue="HealingClock.Time" ReadOnly="true" MaxValue="MaxRecovery" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" Color="Color.Secondary" />
+			<MudRating SelectedValue="HealingClock.Time" ReadOnly="true" MaxValue="MaxRecovery" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" Color="Color.Secondary" aria-label="Current recovery progress"/>
 		}
 		@if (HealingClock.Rollover > 0)
 		{
-			<MudRating SelectedValue="HealingClock.Rollover" ReadOnly="true" MaxValue="HealingClock.Rollover" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" />
+			<MudRating SelectedValue="HealingClock.Rollover" ReadOnly="true" MaxValue="HealingClock.Rollover" FullIcon="@Icons.Material.Filled.Favorite" EmptyIcon="@Icons.Material.Filled.FavoriteBorder" aria-label="Extra recovery progress" />
 		}
 		<MudButton Disabled="!Harm.CanHeal" OnClick="Heal" Variant="Variant.Outlined">Heal</MudButton>
 	</MudStack>
@@ -24,7 +24,7 @@
 	@if (!IsFixMode)
 	{
 		<MudStack Row="true">
-			<MudSelect @bind-Value="RecoveryAmount">
+			<MudSelect @bind-Value="RecoveryAmount" aria-label="Select recovery progress">
 				<MudSelectItem Value="1">
 					<MudIcon Icon="@Icons.Material.Filled.Add" />
 					<MudIcon Icon="@Icons.Material.Filled.Favorite" />
@@ -49,7 +49,7 @@
 					<MudIcon Icon="@Icons.Material.Filled.Favorite" />
 				</MudSelectItem>
 			</MudSelect>
-			<MudButton Disabled="Harm.CanHeal" OnClick="(() => HealingClock.Progress(RecoveryAmount))" Variant="Variant.Outlined">Add</MudButton>
+			<MudButton Disabled="Harm.CanHeal" OnClick="(() => HealingClock.Progress(RecoveryAmount))" Variant="Variant.Outlined" aria-label="Add recovery progress">Add</MudButton>
 		</MudStack>
 	}
 

--- a/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
@@ -5,7 +5,7 @@
 <MudStack>
 	<MudStack Row="true">
 		<MudSelect @bind-Value="SelectedTrauma" Disabled="DisableTraumaSelect" Required="!DisableTraumaSelect" aria-label="Select Trauma">
-			@foreach (var option in TraumaOptions)
+			@foreach (var option in AvailableTraumaOptions)
 			{
 				<MudSelectItem T="string" Value="option">
 					<MudText>@option</MudText>
@@ -40,6 +40,10 @@
 	[Parameter, EditorRequired]
 	public IReadOnlyCollection<string> TraumaOptions { get; set; } = Array.Empty<string>();
 
+	public IReadOnlyCollection<string> AvailableTraumaOptions =>
+		TraumaOptions.Except(Monitor.Trauma.Traumas)
+			.ToArray();
+
 	bool DisableTraumaSelect =>
 		Monitor.Stress.CurrentStress != MonitorStress.MaxStress
 		&& !IsFixMode;
@@ -52,7 +56,7 @@
 
 	string? SelectedTrauma
 	{
-		get => Monitor.Stress.CurrentStress != MonitorStress.MaxStress ? null
+		get => Monitor.Stress.CurrentStress != MonitorStress.MaxStress && !IsFixMode ? null
 			: selectedTrauma;
 		set => selectedTrauma = value;
 	}

--- a/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
@@ -4,7 +4,7 @@
 
 <MudStack>
 	<MudStack Row="true">
-		<MudSelect @bind-Value="SelectedTrauma" Disabled="DisableTraumaSelect" Required="!DisableTraumaSelect">
+		<MudSelect @bind-Value="SelectedTrauma" Disabled="DisableTraumaSelect" Required="!DisableTraumaSelect" aria-label="Select Trauma">
 			@foreach (var option in TraumaOptions)
 			{
 				<MudSelectItem T="string" Value="option">
@@ -12,14 +12,14 @@
 				</MudSelectItem>
 			}
 		</MudSelect>
-		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="DisableAddTrauma" OnClick="AddTrauma" Style="@Constants.Buttons.ButtonDimensionStyle">Trauma</MudButton>
+		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="DisableAddTrauma" OnClick="AddTrauma" Style="@Constants.Buttons.ButtonDimensionStyle" aria-label="Add Trauma">Trauma</MudButton>
 	</MudStack>
 	<MudStack Row="true">
 		@foreach (var option in Monitor.Trauma.Traumas)
 		{
 			@if (IsFixMode)
 			{
-				<MudButton Size="Size.Small" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="(e => RemoveTrauma(option))">@option</MudButton>
+				<MudButton Size="Size.Small" EndIcon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Secondary" OnClick="(e => RemoveTrauma(option))" aria-label="@RemoveTraumaAriaLabel(option)">@option</MudButton>
 			}
 			else
 			{
@@ -80,4 +80,7 @@
 	{
 		Monitor.Trauma.Remove(trauma);
 	}
+
+	string RemoveTraumaAriaLabel(string trauma) =>
+		$"Remove {trauma}";
 }

--- a/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
+++ b/UI/Components/CharacterSheet/SheetMonitorTrauma.razor
@@ -4,7 +4,6 @@
 
 <MudStack>
 	<MudStack Row="true">
-		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="DisableAddTrauma" OnClick="AddTrauma" Style="@Constants.Buttons.ButtonDimensionStyle">Trauma</MudButton>
 		<MudSelect @bind-Value="SelectedTrauma" Disabled="DisableTraumaSelect" Required="!DisableTraumaSelect">
 			@foreach (var option in TraumaOptions)
 			{
@@ -13,6 +12,7 @@
 				</MudSelectItem>
 			}
 		</MudSelect>
+		<MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Outlined" Disabled="DisableAddTrauma" OnClick="AddTrauma" Style="@Constants.Buttons.ButtonDimensionStyle">Trauma</MudButton>
 	</MudStack>
 	<MudStack Row="true">
 		@foreach (var option in Monitor.Trauma.Traumas)

--- a/UI/Components/CharacterSheet/SheetNotebookCard.razor
+++ b/UI/Components/CharacterSheet/SheetNotebookCard.razor
@@ -7,15 +7,15 @@
 		<MudText Typo="Typo.body1">Every time you roll a desperate action, mark xp in that action's attribute.</MudText>
 		<MudText Typo="Typo.body1">At the end of each session, for each item below, mark 1 xp (in your playbook or an attribute) or 2 xp if that item occurred multiple times.</MudText>
 		<MudStack AlignItems="AlignItems.Center" Row="true">
-			<MudRating @bind-SelectedValue="Character.Session.PlaybookExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+			<MudRating @bind-SelectedValue="Character.Session.PlaybookExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" aria-label="Playbook roleplay experience earned" />
 			<MudText Typo="Typo.body1">@PlaybookExperienceCondition.</MudText>
 		</MudStack>
 		<MudStack AlignItems="AlignItems.Center" Row="true">
-			<MudRating @bind-SelectedValue="Character.Session.CharacterExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+			<MudRating @bind-SelectedValue="Character.Session.CharacterExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" aria-label="Character roleplay experience earned" />
 			<MudText Typo="Typo.body1">You expressed your beliefs, drives, heritage, or background.</MudText>
 		</MudStack>
 		<MudStack AlignItems="AlignItems.Center" Row="true">
-			<MudRating @bind-SelectedValue="Character.Session.StruggleExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+			<MudRating @bind-SelectedValue="Character.Session.StruggleExpressions" MaxValue="Session.MaxExpressions" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" aria-label="Struggle roleplay experience earned" />
 			<MudText Typo="Typo.body1">You struggled with issues from your vice or traumas during the session.</MudText>
 		</MudStack>
 	</MudStack>

--- a/UI/Components/CharacterSheet/SheetNotebookCard.razor
+++ b/UI/Components/CharacterSheet/SheetNotebookCard.razor
@@ -19,7 +19,7 @@
 			<MudText Typo="Typo.body1">You struggled with issues from your vice or traumas during the session.</MudText>
 		</MudStack>
 	</MudStack>
-	<MudTextField Label="Notes" @bind-Value="Character.Notebook" Lines="10" />
+	<MudTextField Label="Notes" @bind-Value="Character.Notebook" Lines="10" id="notebook-notes" />
 </SheetCard>
 
 @code

--- a/UI/Components/CharacterSheet/SheetRolodexCard.razor
+++ b/UI/Components/CharacterSheet/SheetRolodexCard.razor
@@ -5,26 +5,26 @@
 	@foreach (var friend in Rolodex.Friends)
 	{
 		<MudStack Row="true">
-			<MudTextField @bind-Value="friend.Entry" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" AdornmentIcon="@GetFriendIcon(friend)" Adornment="Adornment.Start" AdornmentColor="@GetFriendIconColor(friend)" />
+			<MudTextField @bind-Value="friend.Entry" ReadOnly="!IsFixMode" DisableUnderLine="!IsFixMode" AdornmentIcon="@GetFriendIcon(friend)" Adornment="Adornment.Start" AdornmentColor="@GetFriendIconColor(friend)" AdornmentAriaLabel="@GetAdornmentLabel(friend)" aria-label="@friend.Entry" />
 			@if (IsFixMode)
 			{
 				if (friend.Closeness == FriendCloseness.CloseFriend)
 				{
-					<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowDownward" Variant="Variant.Outlined" OnClick="Rolodex.DowngradeCloseFriend">Estrange</MudButton>
+					<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowDownward" Variant="Variant.Outlined" OnClick="Rolodex.DowngradeCloseFriend" aria-label="@ButtonLabel(friend, "Estrange from")">Estrange</MudButton>
 				}
 				else if (friend.Closeness == FriendCloseness.Rival)
 				{
-					<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowUpward" Variant="Variant.Outlined" OnClick="Rolodex.UpgradeRival">Reconcile</MudButton>
+					<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowUpward" Variant="Variant.Outlined" OnClick="Rolodex.UpgradeRival" aria-label="@ButtonLabel(friend, "Reconcile with")">Reconcile</MudButton>
 				}
 				else
 				{
 					if (Rolodex.IsMissingCloseFriend)
 					{
-						<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowUpward" Variant="Variant.Outlined" OnClick="(e => Rolodex.AssignOnlyCloseFriend(friend))">Bond</MudButton>
+						<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowUpward" Variant="Variant.Outlined" OnClick="(e => Rolodex.AssignOnlyCloseFriend(friend))" aria-label="@ButtonLabel(friend, "Bond with")">Bond</MudButton>
 					}
 					if (Rolodex.IsMissingRival)
 					{
-						<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowDownward" Variant="Variant.Outlined" OnClick="(e => Rolodex.AssignOnlyRival(friend))">Betray</MudButton>
+						<MudButton Style="width: 120px;" Size="Size.Small" EndIcon="@Icons.Material.Filled.ArrowDownward" Variant="Variant.Outlined" OnClick="(e => Rolodex.AssignOnlyRival(friend))" aria-label="@ButtonLabel(friend, "Betray")">Betray</MudButton>
 					}
 				}
 			}
@@ -55,4 +55,14 @@
 		FriendCloseness.Rival => Color.Warning,
 		_ => Color.Default
 	};
+
+	static string GetAdornmentLabel(RolodexFriend friend) => friend.Closeness switch
+	{
+		FriendCloseness.CloseFriend => "Close friend",
+		FriendCloseness.Rival => "Rival",
+		_ => "Friend"
+	};
+
+	static string ButtonLabel(RolodexFriend friend, string action) =>
+		$"{action} {friend.Entry}";
 }

--- a/UI/Components/CharacterSheet/SheetTalentAction.razor
+++ b/UI/Components/CharacterSheet/SheetTalentAction.razor
@@ -7,14 +7,14 @@
 <MudStack Row="true">
 	@if (IsFixMode)
 	{
-		<MudRating Size="Size.Small" @bind-SelectedValue="FixModeRating" MaxValue="Action.MaxRating" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+		<MudRating Size="Size.Small" @bind-SelectedValue="FixModeRating" MaxValue="Action.MaxRating" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" aria-label="@RatingLabel" />
 		<MudText>@ActionName</MudText>
 	}
 	else
 	{
 		if (CanLevelUp)
 		{
-			<MudIconButton Title="@LevelUpTitle" Variant="Variant.Filled" Size="Size.Small" Disabled="Action.HasMaxRating" Icon="@Icons.Material.Filled.Add" OnClick="LevelUp" Color="Color.Primary" />
+			<MudIconButton Title="@LevelUpTitle" Variant="Variant.Filled" Size="Size.Small" Disabled="Action.HasMaxRating" Icon="@Icons.Material.Filled.Add" OnClick="LevelUp" Color="Color.Primary" aria-label="@LevelUpLabel" />
 		}
 		<MudText>@Text</MudText>
 	}
@@ -67,4 +67,10 @@
 
 	void Notify() =>
 		SheetJank.NotifyAttributeChanged(AttributeName);
+
+	string RatingLabel =>
+		$"Set {ActionName} rating";
+
+	string LevelUpLabel =>
+		$"Level up {ActionName}";
 }

--- a/UI/Components/CharacterSheet/SheetTalentAttribute.razor
+++ b/UI/Components/CharacterSheet/SheetTalentAttribute.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 
 <MudStack>
-	<MudRating @bind-SelectedValue="Attribute.Experience.Points" MaxValue="Attribute!.Experience.MaxPoints" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
+	<MudRating @bind-SelectedValue="Attribute.Experience.Points" MaxValue="Attribute.Experience.MaxPoints" FullIcon="@Icons.Material.Filled.CheckBox" EmptyIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" Color="Color.Primary" />
 	<MudText Typo="Typo.h6">@Attribute.Rating @Name</MudText>
 	@foreach (var actionByName in Attribute.ActionsByName)
 	{
@@ -41,4 +41,7 @@
 		if (attributeName == Name)
 			StateHasChanged();
 	}
+
+	string RatingLabel =>
+		$"Set {Name} experience points";
 }

--- a/UI/Components/NewCharacter/NewCharacterActionDotsCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterActionDotsCard.razor
@@ -31,11 +31,13 @@
 							<MudStack Row="true" AlignItems="AlignItems.Center">
 								<MudToggleIconButton Toggled="@action.IsDotOneFilled" ToggledChanged="@action.ToggleDotOne"
 									Disabled="!ViewModel.IsDotOneEnabled(action)"
-									Icon="@Icons.Material.Filled.Circle" ToggledIcon="@Icons.Material.Filled.CheckCircle" />
+									Icon="@Icons.Material.Filled.Circle" ToggledIcon="@Icons.Material.Filled.CheckCircle"
+									aria-label="@DotLabel(action.Name, 1)" />
 								<MudDivider Vertical="true" FlexItem="true" />
 								<MudToggleIconButton Toggled="@action.IsDotTwoFilled" ToggledChanged="@action.ToggleDotTwo"
 									Disabled="!ViewModel.IsDotTwoEnabled(action)"
-									Icon="@Icons.Material.Filled.Circle" ToggledIcon="@Icons.Material.Filled.CheckCircle" />
+									Icon="@Icons.Material.Filled.Circle" ToggledIcon="@Icons.Material.Filled.CheckCircle" 
+									aria-label="@DotLabel(action.Name, 2)" />
 								<MudText>@action.Name</MudText>
 							</MudStack>
 						</TitleContent>
@@ -67,4 +69,7 @@
 
 		base.OnParametersSet();
 	}
+
+	static string DotLabel(string actionName, int dot) =>
+		$"{actionName} dot {dot}";
 }

--- a/UI/Components/NewCharacter/NewCharacterBackgroundCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterBackgroundCard.razor
@@ -7,7 +7,7 @@
 		<MudText Typo="Typo.h6">Choose a background</MudText>
 	</MudCardHeader>
 	<MudCardContent>
-		<MudSelect @bind-Value="Background.Name" Label="Background">
+		<MudSelect @bind-Value="Background.Name" Label="Background" id="select-background">
 			@foreach (var option in BackgroundSettings)
 			{
 				<MudSelectItem T="string" Value="option.Name">
@@ -17,7 +17,7 @@
 			}
 		</MudSelect>
 		<MudText>@Example()</MudText>
-		<MudTextField @bind-Value="Background.Description" HelperText="What did you do before joining the crew?" Placeholder="A snoozing, indebted student" aria-label="Background description" />
+		<MudTextField @bind-Value="Background.Description" HelperText="What did you do before joining the crew?" Placeholder="A snoozing, indebted student" aria-label="Background description" id="background-description" />
 	</MudCardContent>
 </MudCard>
 

--- a/UI/Components/NewCharacter/NewCharacterBackgroundCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterBackgroundCard.razor
@@ -17,7 +17,7 @@
 			}
 		</MudSelect>
 		<MudText>@Example()</MudText>
-		<MudTextField @bind-Value="Background.Description" HelperText="What did you do before joining the crew?" Placeholder="A snoozing, indebted student" />
+		<MudTextField @bind-Value="Background.Description" HelperText="What did you do before joining the crew?" Placeholder="A snoozing, indebted student" aria-label="Background description" />
 	</MudCardContent>
 </MudCard>
 

--- a/UI/Components/NewCharacter/NewCharacterFriendsCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterFriendsCard.razor
@@ -10,7 +10,7 @@
 	</MudCardHeader>
 	<MudCardContent>
 		<MudStack>
-			<MudSelect T="RolodexFriend" Label="Close Friend" Value="CloseFriend" ValueChanged="OnCloseFriendChanged">
+			<MudSelect T="RolodexFriend" Label="Close Friend" Value="CloseFriend" ValueChanged="OnCloseFriendChanged" id="select-close-friend">
 				@foreach (var friend in AvailableCloseFriends)
 				{
 					<MudSelectItem T="RolodexFriend" Value="friend">
@@ -18,7 +18,7 @@
 					</MudSelectItem>
 				}
 			</MudSelect>
-			<MudSelect T="RolodexFriend" Label="Rival" Value="Rival" ValueChanged="OnRivalChanged">
+			<MudSelect T="RolodexFriend" Label="Rival" Value="Rival" ValueChanged="OnRivalChanged" id="select-rival">
 				@foreach (var friend in AvailableRivals)
 				{
 					<MudSelectItem T="RolodexFriend" Value="friend">

--- a/UI/Components/NewCharacter/NewCharacterHeritageCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterHeritageCard.razor
@@ -7,7 +7,7 @@
 		<MudText Typo="Typo.h6">Choose a heritage</MudText>
 	</MudCardHeader>
 	<MudCardContent>
-		<MudSelect @bind-Value="Heritage.Name" Label="Heritage">
+		<MudSelect @bind-Value="Heritage.Name" Label="Heritage" id="select-heritage">
 			@foreach (var option in HeritageSettings)
 			{
 				<MudSelectItem T="string" Value="option.Name">
@@ -17,7 +17,7 @@
 			}
 		</MudSelect>
 		<MudText>@Elaboration()</MudText>
-		<MudTextField @bind-Value="Heritage.Description" HelperText="Share a detail about your family life" Placeholder="Exiled nobility, now maladjusted factory laborers" aria-label="Heritage description" />
+		<MudTextField @bind-Value="Heritage.Description" HelperText="Share a detail about your family life" Placeholder="Exiled nobility, now maladjusted factory laborers" aria-label="Heritage description" id="heritage-description" />
 	</MudCardContent>
 </MudCard>
 

--- a/UI/Components/NewCharacter/NewCharacterHeritageCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterHeritageCard.razor
@@ -17,7 +17,7 @@
 			}
 		</MudSelect>
 		<MudText>@Elaboration()</MudText>
-		<MudTextField @bind-Value="Heritage.Description" HelperText="Share a detail about your family life" Placeholder="Exiled nobility, now maladjusted factory laborers" />
+		<MudTextField @bind-Value="Heritage.Description" HelperText="Share a detail about your family life" Placeholder="Exiled nobility, now maladjusted factory laborers" aria-label="Heritage description" />
 	</MudCardContent>
 </MudCard>
 

--- a/UI/Components/NewCharacter/NewCharacterIdentificationCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterIdentificationCard.razor
@@ -7,15 +7,9 @@
 	</MudCardHeader>
 	<MudCardContent>
 		<MudStack>
-			<MudTextField @bind-Value="Dossier.Name"
-				Label="Name"
-				Placeholder="Noggs Kessarin" />
-			<MudTextField @bind-Value="Dossier.Alias"
-				Label="Alias"
-				Placeholder="Thistle" />
-			<MudTextField @bind-Value="Dossier.Look"
-				Label="Look"
-				Placeholder="Ambiguously gendered, brooding, and weathered, in a signature heavy jacket and work boots" />
+			<MudTextField @bind-Value="Dossier.Name" Label="Name" Placeholder="Noggs Kessarin" id="dossier-name" />
+			<MudTextField @bind-Value="Dossier.Alias" Label="Alias" Placeholder="Thistle" id="dossier-alias" />
+			<MudTextField @bind-Value="Dossier.Look" Label="Look" Placeholder="Ambiguously gendered, brooding, and weathered, in a signature heavy jacket and work boots" id="dossier-look" />
 		</MudStack>
 	</MudCardContent>
 </MudCard>

--- a/UI/Components/NewCharacter/NewCharacterSpecialAbilityCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterSpecialAbilityCard.razor
@@ -11,7 +11,7 @@
 		<MudStack>
 			<MudStack>
 				<MudText>If you're unsure which one to pick, the first is considered a good default choice.</MudText>
-				<MudSelect T="PlaybookSpecialAbility" Value="ChosenAbility" ValueChanged="OnChosenAbilityChanged" Label="Special Ability" ToStringFunc="a => a?.Name">
+				<MudSelect T="PlaybookSpecialAbility" Value="ChosenAbility" ValueChanged="OnChosenAbilityChanged" Label="Special Ability" ToStringFunc="a => a?.Name" id="select-playbook-ability">
 					@foreach (var ability in AvailableAbilities)
 					{
 						<MudSelectItem T="PlaybookSpecialAbility" Value="ability">
@@ -25,7 +25,7 @@
 			{
 				<MudStack>
 					<MudText>@GameSetting.Name also has unique starting abilities.</MudText>
-					<MudSelect T="PlaybookSpecialAbility" Value="ChosenStartingAbility" ValueChanged="OnChosenStartingAbilityChanged" Label="Starting Ability" ToStringFunc="a => a?.Name">
+					<MudSelect T="PlaybookSpecialAbility" Value="ChosenStartingAbility" ValueChanged="OnChosenStartingAbilityChanged" Label="Starting Ability" ToStringFunc="a => a?.Name" id="select-playbook-starting-ability">
 						@foreach (var ability in AvailableStartingAbilities)
 						{
 							<MudSelectItem T="PlaybookSpecialAbility" Value="ability">

--- a/UI/Components/NewCharacter/NewCharacterViceCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterViceCard.razor
@@ -7,7 +7,7 @@
 	</MudCardHeader>
 	<MudCardContent>
 		<MudStack>
-			<MudSelect @bind-Value="Vice.Name" Label="Vice">
+			<MudSelect @bind-Value="Vice.Name" Label="Vice" id="select-vice">
 				@foreach (var option in ViceSettings)
 				{
 					<MudSelectItem T="string" Value="option.Name">
@@ -17,7 +17,7 @@
 				}
 			</MudSelect>
 			<MudText>@Elaboration()</MudText>
-			<MudTextField @bind-Value="Vice.Description" HelperText="@HelperText()" Placeholder="@ExamplePlaceholder()" aria-label="Vice description" />
+			<MudTextField @bind-Value="Vice.Description" HelperText="@HelperText()" Placeholder="@ExamplePlaceholder()" aria-label="Vice description" id="vice-description" />
 			@if (HasExamples)
 			{
 				<MudExpansionPanels>

--- a/UI/Components/NewCharacter/NewCharacterViceCard.razor
+++ b/UI/Components/NewCharacter/NewCharacterViceCard.razor
@@ -17,7 +17,7 @@
 				}
 			</MudSelect>
 			<MudText>@Elaboration()</MudText>
-			<MudTextField @bind-Value="Vice.Description" HelperText="@HelperText()" Placeholder="@ExamplePlaceholder()" />
+			<MudTextField @bind-Value="Vice.Description" HelperText="@HelperText()" Placeholder="@ExamplePlaceholder()" aria-label="Vice description" />
 			@if (HasExamples)
 			{
 				<MudExpansionPanels>

--- a/UI/Pages/Index.razor
+++ b/UI/Pages/Index.razor
@@ -51,7 +51,7 @@
 			</MudCardHeader>
 			<MudCardContent>
 				<MudStack>
-					<MudSelect @bind-Value="SelectedGameFile" ToStringFunc="gameFile => gameFile.Name" Label="Select a Game"  Style="max-width: 215px;">
+					<MudSelect @bind-Value="SelectedGameFile" ToStringFunc="gameFile => gameFile.Name" Label="Select a Game"  Style="max-width: 215px;" id="select-a-game">
 						@foreach (var gameFile in AvailableGameFiles)
 						{
 							<MudSelectItem T="GameFile" Value="gameFile">

--- a/UI/Shared/MainLayout.razor
+++ b/UI/Shared/MainLayout.razor
@@ -33,9 +33,9 @@
 	private static MudTheme InitializeMudTheme()
 	{
 		var theme = new MudTheme();
-		var goodPurple = theme.PaletteDark.Primary;
-		theme.PaletteDark.Primary = Colors.DeepOrange.Lighten1;
-		theme.PaletteDark.Tertiary = goodPurple;
+		theme.PaletteDark.Primary = Colors.DeepOrange.Lighten2;
+		theme.PaletteDark.Secondary = Colors.Red.Accent4;
+		theme.PaletteDark.Tertiary = Colors.DeepPurple.Accent2;
 		return theme;
 	}
 

--- a/UI/Shared/MainLayout.razor
+++ b/UI/Shared/MainLayout.razor
@@ -10,7 +10,7 @@
 		<MudImage Src="icon-192.png" ObjectFit="ObjectFit.ScaleDown" Alt="Icon of a blade piercing a character sheet" Style="@IconStyle" />
 	</MudAppBar>
 	<MudDrawer @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
-		<MudText Style="display: flex; justify-content: right; margin-right: 10px" Typo="Typo.caption">Version 9.1</MudText>
+		<MudText Style="display: flex; justify-content: right; margin-right: 10px" Typo="Typo.caption">Version 10</MudText>
 		<MudNavLink Href="">Home</MudNavLink>
 		<MudNavLink Href="@Paths.Tips">Tip Jar</MudNavLink>
 	</MudDrawer>

--- a/UI/Shared/MainLayout.razor
+++ b/UI/Shared/MainLayout.razor
@@ -5,7 +5,7 @@
 
 <MudLayout>
 	<MudAppBar Elevation="1">
-		<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+		<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Title="App Bar Toggle" />
 		<MudText Typo="Typo.h5" Class="ml-3">Blades in the Sheets</MudText>
 		<MudImage Src="icon-192.png" ObjectFit="ObjectFit.ScaleDown" Alt="Icon of a blade piercing a character sheet" Style="@IconStyle" />
 	</MudAppBar>

--- a/UI/wwwroot/manifest.webmanifest
+++ b/UI/wwwroot/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
 	"name": "Blades in the Sheets",
 	"short_name": "BitD Sheets",
-	"version": "9.1",
+	"version": "10",
 	"start_url": "./",
 	"display": "standalone",
 	"background_color": "#32333dff",


### PR DESCRIPTION
I don't have a screen reader yet, but I was able to try to meet all the messages I understood from the WAVE extension.

I'm unsure what to do about MudRating components for the moment. WAVE says it should have a fieldset. I tried applying an id and an aria-label to the MudRating, but it seems not to make WAVE happy. Each "rating" (like experience checkbox within the app) is considered its own radio button by WAVE, which causes it to complain about them not having compliant labels. However, MudRating seems to apply aria-hidden to each of the radio buttons, so even if it were compliant, it seems like it would be hidden from a screen reader.

This is my major remaining confusion with the WAVE extension specifically.

My major concern outside of that is that I need to start testing with a screen reader.

This update also comes with some color changes for contrast compliance and some component re-orders for better tabbing. I have retested all the tabbing behavior on the character sheet and it seems to be in a better place. However, the MudExpansionPanels do not seem to have an intuitive way to be targeted by tabbing, so I'm not sure how to trigger the expansion by keyboard.