### PR TITLE
Push net9 separately for testing's sake. Don't want to have a data migration and a framework upgrade on the same site update.

### DIFF
--- a/Models/Characters/Gear.cs
+++ b/Models/Characters/Gear.cs
@@ -23,6 +23,8 @@ public class Gear
 
 	public int MaxBulk => Commitment.MaxBulk;
 
+	public bool IsCommitmentLocked { get; set; } = false;
+
 	internal int AvailableBulk => Commitment.MaxBulk - Loadout.Sum(i => i.Bulk);
 
 	public bool CanAddAvailableItem(string itemName) => !AvailableGearByName.ContainsKey(itemName);

--- a/Models/Characters/GearCommitment.cs
+++ b/Models/Characters/GearCommitment.cs
@@ -1,10 +1,35 @@
-﻿namespace Models.Characters;
+﻿using System.Collections.Immutable;
+
+namespace Models.Characters;
 
 public class GearCommitment
 {
+	public IDictionary<LoadCommitmentOption, int> MaxBulkByCommitmentOption { get; private set; } = AllLoadCommitmentOptions.ToDictionary
+	(
+		load => load,
+		load => (int)load
+	);
+
+	public void SetMaxBulkForCommitmentOption(LoadCommitmentOption load, int bulk) =>
+		MaxBulkByCommitmentOption[load] = bulk;
+
 	public LoadCommitmentOption Commitment { get; set; }
 
-	public int MaxBulk => (int)Commitment;
+	public int MaxBulk => MaxBulkByCommitmentOption[Commitment];
+
+	public static readonly ImmutableArray<LoadCommitmentOption> AllLoadCommitmentOptions =
+	[
+		LoadCommitmentOption.None,
+		LoadCommitmentOption.Light,
+		LoadCommitmentOption.Normal,
+		LoadCommitmentOption.Heavy,
+		LoadCommitmentOption.Encumbered
+	];
+
+	public static readonly ImmutableArray<LoadCommitmentOption> EditableLoadCommitmentOptions =
+		AllLoadCommitmentOptions
+		.Skip(1)
+		.ToImmutableArray();
 }
 
 public enum LoadCommitmentOption

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Persistence.Test/MigratorTests.cs
+++ b/Persistence.Test/MigratorTests.cs
@@ -20,7 +20,15 @@ public class MigratorTests
 	{
 		var output = this.migrator.Migrate(JsonJunk.SpiderJsonV1);
 		output.Should().NotContainAny("\"Source\":", "\"PlaybookDefault\":");
-		output.Should().ContainAll("\"ActionsByName\":", "\"AttributesByName\":", "\"Version\": 2");
+		output.Should().ContainAll
+		(
+			"\"ActionsByName\":",
+			"\"AttributesByName\":",
+			"\"Version\": 3",
+			"\"Language\": \"English\"",
+			"\"MaxBulkByCommitmentOption\"",
+			"\"IsCommitmentLocked\": false"
+		);
 		this.serializer.Deserialize(output);
 	}
 

--- a/Persistence.Test/Persistence.Test.csproj
+++ b/Persistence.Test/Persistence.Test.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-		<PackageReference Include="xunit" Version="2.8.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Persistence.Test/SerializerTests.cs
+++ b/Persistence.Test/SerializerTests.cs
@@ -187,6 +187,25 @@ public class SerializerTests
 	}
 
 	[Fact]
+	public void Serializer_Deserializes_GearCommitments()
+	{
+		var migratedJson = this.migrationHandler.Migrate(JsonJunk.SpiderJsonV1);
+		var character = this.serializer.Deserialize(migratedJson);
+
+		character.Should().NotBeNull();
+		character.Gear.Commitment.Commitment = LoadCommitmentOption.Light;
+		character.Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Light] = 5;
+		character.Gear.IsCommitmentLocked = true;
+
+		var json = this.serializer.Serialize(character);
+		character = this.serializer.Deserialize(json);
+
+		character.Gear.Commitment.Commitment.Should().Be(LoadCommitmentOption.Light);
+		character.Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Light].Should().Be(5);
+		character.Gear.IsCommitmentLocked.Should().BeTrue();
+	}
+
+	[Fact]
 	public void Serializer_Deserializes_RealCharacter()
 	{
 		var migratedJson = this.migrationHandler.Migrate(JsonJunk.SpiderJsonV1);

--- a/Persistence/Json/Migrations/IMigrationHandler.cs
+++ b/Persistence/Json/Migrations/IMigrationHandler.cs
@@ -4,7 +4,7 @@ namespace Persistence.Json.Migrations;
 
 public interface IMigrationHandler
 {
-	const int MaxVersion = 2;
+	const int MaxVersion = 3;
 
 	string Migrate(string json);
 

--- a/Persistence/Json/Migrations/MigrationHandler.cs
+++ b/Persistence/Json/Migrations/MigrationHandler.cs
@@ -25,7 +25,8 @@ public class MigrationHandler : IMigrationHandler
 		);
 
 		// Chain future migrations here
-		var final = jsonVersion.MigrateV2();
+		var final = jsonVersion.MigrateV2()
+			.MigrateV3();
 
 		return final.Json.ToString();
 	}

--- a/Persistence/Json/Migrations/Version2.cs
+++ b/Persistence/Json/Migrations/Version2.cs
@@ -4,10 +4,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static Models.Legacy.RetiredOptions;
 using static Persistence.Json.Migrations.IMigrationHandler;
+using static Persistence.Json.Migrations.VersionFunctions;
 
 namespace Persistence.Json.Migrations;
 
-public static class Version2
+internal static class Version2
 {
 	public static JsonVersion MigrateV2(this JsonVersion migration)
 	{
@@ -104,39 +105,6 @@ public static class Version2
 			property.Remove();
 	}
 
-	private static void NestProperty(JObject json, string path, string childPropertyName, params string[] excludingPropertyNames)
-	{
-		var parentProperty = json.SelectToken(path) as JObject
-			?? throw Error(path);
-
-		var children = parentProperty.DeepClone();
-
-		foreach (var child in children.Children().IntersectBy(excludingPropertyNames, token => (token as JProperty)?.Name).ToArray())
-			child.Remove();
-
-		foreach (var child in parentProperty.Children().ExceptBy(excludingPropertyNames, token => (token as JProperty)?.Name).ToArray())
-			child.Remove();
-
-		parentProperty.Add(childPropertyName, children);
-	}
-
-	private static void AddObject<T>(JObject json, string path, string objectName, T obj) where T : notnull
-	{
-		var parentProperty = json.SelectToken(path) as JObject
-			?? throw Error(path);
-
-		var addable = JObject.FromObject(obj);
-		parentProperty.Add(objectName, addable);
-	}
-
-	private static void AddProperty<T>(JObject json, string path, string propertyName, T propertyValue)
-	{
-		var parentProperty = json.SelectToken(path) as JObject
-			?? throw Error(path);
-
-		parentProperty.Add(propertyName, new JValue(propertyValue));
-	}
-
 	private static void ReplaceTraumaOption(JObject json)
 	{
 		var optionProperty = json.SelectToken("$.Monitor.Trauma.TraumaSet") as JArray
@@ -151,7 +119,4 @@ public static class Version2
 		foreach (var child in children)
 			optionProperty.Add(child);
 	}
-
-	private static JsonException Error(string jPath) =>
-		new($"Cannot migrate to v2. Cannot find JPATH {jPath}");
 }

--- a/Persistence/Json/Migrations/Version3.cs
+++ b/Persistence/Json/Migrations/Version3.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json.Linq;
+using static Persistence.Json.Migrations.IMigrationHandler;
+using static Persistence.Json.Migrations.VersionFunctions;
+
+namespace Persistence.Json.Migrations;
+
+internal static class Version3
+{
+	const int Version = 3;
+
+	public static JsonVersion MigrateV3(this JsonVersion migration)
+	{
+		if (migration.Version >= Version)
+			return migration;
+
+		return new
+		(
+			Upgrade(migration.Json),
+			Version
+		);
+	}
+
+	public static JObject Upgrade(JObject jObject)
+	{
+		AddProperty(jObject, "$.Gear", "IsCommitmentLocked", false);
+
+		AddObject(jObject, "$.Gear.Commitment", "MaxBulkByCommitmentOption", new
+		{
+			None = 0,
+			Light = 3,
+			Normal = 5,
+			Heavy = 6,
+			Encumbered = 9
+		});
+
+		DefaultLanguage(jObject);
+
+		ReplaceVersion(jObject, Version);
+
+		return jObject;
+	}
+
+	private static JObject DefaultLanguage(JObject jObject)
+	{
+		var languagePath = jObject.SelectToken("$.Language");
+
+		if (languagePath != null)
+			return jObject;
+
+		AddProperty(jObject, "$", "Language", Models.Settings.Constants.Languages.English);
+		return jObject;
+	}
+}

--- a/Persistence/Json/Migrations/VersionFunctions.cs
+++ b/Persistence/Json/Migrations/VersionFunctions.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Persistence.Json.Migrations;
+
+internal static class VersionFunctions
+{
+	internal static void NestProperty(JObject json, string path, string childPropertyName, params string[] excludingPropertyNames)
+	{
+		var parentProperty = json.SelectToken(path) as JObject
+			?? throw Error(path);
+
+		var children = parentProperty.DeepClone();
+
+		foreach (var child in children.Children().IntersectBy(excludingPropertyNames, token => (token as JProperty)?.Name).ToArray())
+			child.Remove();
+
+		foreach (var child in parentProperty.Children().ExceptBy(excludingPropertyNames, token => (token as JProperty)?.Name).ToArray())
+			child.Remove();
+
+		parentProperty.Add(childPropertyName, children);
+	}
+
+	internal static void AddObject<T>(JObject json, string path, string objectName, T obj) where T : notnull
+	{
+		var parentProperty = json.SelectToken(path) as JObject
+			?? throw Error(path);
+
+		var addable = JObject.FromObject(obj);
+		parentProperty.Add(objectName, addable);
+	}
+
+	internal static void AddProperty<T>(JObject json, string path, string propertyName, T propertyValue)
+	{
+		var parentProperty = json.SelectToken(path) as JObject
+			?? throw Error(path);
+
+		parentProperty.Add(propertyName, new JValue(propertyValue));
+	}
+
+	internal static void ReplaceVersion(JObject json, int version)
+	{
+		ReplacePropertyValue(json, "$", "Version", version);
+	}
+
+	internal static void ReplacePropertyValue<T>(JObject json, string path, string propertyName, T propertyValue)
+	{
+		var pathIncludingProperty = $"{path}.{propertyName}";
+
+		var toReplace = json.SelectToken(pathIncludingProperty)?.Parent as JProperty
+			?? throw Error(pathIncludingProperty);
+
+		toReplace.Replace(new JProperty(propertyName, propertyValue));
+	}
+
+	internal static JsonException Error(string jPath) =>
+		new($"Cannot migrate to v2. Cannot find JPATH {jPath}");
+}

--- a/Persistence/Persistence.csproj
+++ b/Persistence/Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
 	</ItemGroup>

--- a/UI/Components/CharacterSheet/SheetGearCard.razor
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor
@@ -10,20 +10,39 @@
 	<div class="horizontal-stack jsb">
 		<FluentRadioGroup Class="wrap-row jsb" @bind-Value="Gear.Commitment.Commitment">
 			<FluentRadio Value="LoadCommitmentOption.None" Disabled="!RadioCommitmentsEnabled">@LoadCommitmentOption.None</FluentRadio>
-			<FluentRadio Value="LoadCommitmentOption.Light" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Light) @LoadCommitmentOption.Light</FluentRadio>
-			<FluentRadio Value="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Normal) @LoadCommitmentOption.Normal</FluentRadio>
-			<FluentRadio Value="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Heavy) @LoadCommitmentOption.Heavy</FluentRadio>
-			<FluentRadio Value="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@((int)LoadCommitmentOption.Encumbered) @LoadCommitmentOption.Encumbered</FluentRadio>
+			<FluentRadio Value="LoadCommitmentOption.Light" Disabled="!RadioCommitmentsEnabled">@(Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Light]) @LoadCommitmentOption.Light</FluentRadio>
+			<FluentRadio Value="LoadCommitmentOption.Normal" Disabled="!RadioCommitmentsEnabled">@(Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Normal]) @LoadCommitmentOption.Normal</FluentRadio>
+			<FluentRadio Value="LoadCommitmentOption.Heavy" Disabled="!RadioCommitmentsEnabled">@(Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Heavy]) @LoadCommitmentOption.Heavy</FluentRadio>
+			<FluentRadio Value="LoadCommitmentOption.Encumbered" Disabled="!RadioCommitmentsEnabled">@(Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Encumbered]) @LoadCommitmentOption.Encumbered</FluentRadio>
 		</FluentRadioGroup>
-		@if (CommitmentLocked)
+		@if (Gear.IsCommitmentLocked)
 		{
-			<FluentButton Class="min-button" Appearance="Appearance.Accent" OnClick="() => { ClearCommitments(); CommitmentLocked = false; }">Reset</FluentButton>
+			<FluentButton Class="min-button" Appearance="Appearance.Accent" OnClick="() => { ClearCommitments(); Gear.IsCommitmentLocked = false; }">Reset</FluentButton>
 		}
 		else
 		{
-			<FluentButton Class="min-button" IconStart="new Icons.Filled.Size20.LockClosed()" Appearance="Appearance.Accent" OnClick="() => CommitmentLocked = true">Commit</FluentButton>
+			<FluentButton Class="min-button" IconStart="new Icons.Filled.Size20.LockClosed()" Appearance="Appearance.Accent" OnClick="() => Gear.IsCommitmentLocked = true">Commit</FluentButton>
 		}
 	</div>
+	@if (IsFixMode)
+	{
+		<div class="gear-row">
+			<div class="commitment-edit">
+				<FluentNumberField Class="gear-commitment-edit" Style="width: 70px;" @bind-Value="Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Light]" Label="@($"{LoadCommitmentOption.Light}:")" Min="0" Max="99" />
+			</div>
+			<div class="commitment-edit">
+				<FluentNumberField Class="gear-commitment-edit" Style="width: 70px;" @bind-Value="Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Normal]" Label="@($"{LoadCommitmentOption.Normal}:")" Min="0" Max="99" />
+			</div>
+		</div>
+		<div class="gear-row">
+			<div class="commitment-edit">
+				<FluentNumberField Class="gear-commitment-edit" Style="width: 70px;" @bind-Value="Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Heavy]" Label="@($"{LoadCommitmentOption.Heavy}:")" Min="0" Max="99" />
+			</div>
+			<div class="commitment-edit">
+				<FluentNumberField Class="gear-commitment-edit" Style="width: 70px;" @bind-Value="Gear.Commitment.MaxBulkByCommitmentOption[LoadCommitmentOption.Encumbered]" Label="@($"{LoadCommitmentOption.Encumbered}:")" Min="0" Max="99" />
+			</div>
+		</div>
+	}
 	<h5>Loadout</h5>
 	<div>
 		@if (IsFixMode)
@@ -54,7 +73,7 @@
 		{
 			@if (!IsFixMode)
 			{
-				<FluentButton Class="gear-button" Appearance="Appearance.Outline" IconStart="new Icons.Regular.Size20.AddCircle()" Disabled="!Character.CanCommitGear(item) || !CommitmentLocked" OnClick="() => CommitGear(item)" Title="@($"Commit {@item.Display()}")">@item.Display()</FluentButton>
+				<FluentButton Class="gear-button" Appearance="Appearance.Outline" IconStart="new Icons.Regular.Size20.AddCircle()" Disabled="!Character.CanCommitGear(item) || !Gear.IsCommitmentLocked" OnClick="() => CommitGear(item)" Title="@($"Commit {@item.Display()}")">@item.Display()</FluentButton>
 			}
 			else
 			{

--- a/UI/Components/CharacterSheet/SheetGearCard.razor.cs
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor.cs
@@ -23,9 +23,7 @@ public partial class SheetGearCard
 
 	public bool IsFixMode { get; set; }
 
-	bool CommitmentLocked { get; set; } = false;
-
-	bool RadioCommitmentsEnabled => IsFixMode || !CommitmentLocked;
+	bool RadioCommitmentsEnabled => IsFixMode || !Gear.IsCommitmentLocked;
 
 	public void CommitGear(GearItem item)
 	{

--- a/UI/Components/CharacterSheet/SheetGearCard.razor.css
+++ b/UI/Components/CharacterSheet/SheetGearCard.razor.css
@@ -17,3 +17,13 @@
 	row-gap: 10px;
 	margin-left: -5px;
 }
+
+.commitment-edit {
+	flex-grow: 1;
+}
+
+::deep .gear-commitment-edit {
+	min-height: 40px;
+	width: 70px;
+	padding-left: 5px;
+}

--- a/UI/Components/NewCharacter/NewCharacterFriendsCard.razor.cs
+++ b/UI/Components/NewCharacter/NewCharacterFriendsCard.razor.cs
@@ -44,7 +44,7 @@ public partial class NewCharacterFriendsCard
 		Rolodex.ReplaceFriends(friends);
 
 		AvailableFriendOptions = Rolodex.Friends
-			.Select(f => new Option<RolodexFriend> { Value = f, Text = f })
+			.Select(f => new Option<RolodexFriend> { Value = f, Text = f.Entry })
 			.Prepend(new Option<RolodexFriend> { Value = null, Text = null, Disabled = true, Selected = true })
 			.ToArray();
 

--- a/UI/Pages/CharacterSheet.razor
+++ b/UI/Pages/CharacterSheet.razor
@@ -10,7 +10,7 @@
 @inject ILoader Loader
 @inject IToastService Toaster
 @inject HotKeys Hotkeys
-@implements IDisposable
+@implements IAsyncDisposable
 
 <FluentGrid Justify="JustifyContent.Center" Style="padding-bottom: 40px;">
 	<FluentGridItem xs="12" lg="6">

--- a/UI/Pages/CharacterSheet.razor.cs
+++ b/UI/Pages/CharacterSheet.razor.cs
@@ -60,9 +60,10 @@ public partial class CharacterSheet
 		isSaving = false;
 	}
 
-	public void Dispose()
+	public async ValueTask DisposeAsync()
 	{
-		this.hotKeysContext?.Dispose();
+		if (this.hotKeysContext != null)
+			await this.hotKeysContext.DisposeAsync();
 		GC.SuppressFinalize(this);
 	}
 }

--- a/UI/Pages/Index.razor.cs
+++ b/UI/Pages/Index.razor.cs
@@ -105,7 +105,7 @@ public partial class Index
 	{
 		var buffer = new byte[fileEvent.Size];
 		await using var fs = fileEvent.Stream;
-		await fs!.ReadAsync(buffer);
+		await fs!.ReadExactlyAsync(buffer);
 		var json = Encoding.Unicode.GetString(buffer);
 		await Storage.PutFile(json);
 	}

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
@@ -13,12 +13,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.7.2" />
-		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.7.2" />
-		<PackageReference Include="PublishSPAforGitHubPages.Build" Version="2.2.0" />
-		<PackageReference Include="Toolbelt.Blazor.HotKeys2" Version="4.1.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.4" />
+		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.4" />
+		<PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.0" />
+		<PackageReference Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/UI/wwwroot/manifest.webmanifest
+++ b/UI/wwwroot/manifest.webmanifest
@@ -4,7 +4,6 @@
 	"version": "15",
 	"start_url": "./",
 	"display": "standalone",
-	"background_color": "#32333dff",
 	"theme_color": "#776be7ff",
 	"prefer_related_applications": false,
 	"icons": [


### PR DESCRIPTION
- Upgrade to dotnet9
- Support editing load commitment amounts
- Planning to support editing stress amounts as well

Close #20 
Close #19 
