### PR TITLE
Fix/migration error messages

### DIFF
--- a/Models/Characters/CharacterArmor.cs
+++ b/Models/Characters/CharacterArmor.cs
@@ -5,9 +5,9 @@ namespace Models.Characters;
 
 public partial class Character // Armor
 {
-	private static readonly string[] StandardArmors = ["Armor", "Armure"];
-	private static readonly string[] HeavyArmors = ["+Heavy", "+Lourde"];
-	private static readonly string[] SpecialArmors = ["special armor", "armure spéciale"];
+	private static readonly string[] StandardArmors = ["Armor", "Armure", "Доспех"];
+	private static readonly string[] HeavyArmors = ["+Heavy", "+Lourde", "+Тяжёлый"];
+	private static readonly string[] SpecialArmors = ["special armor", "armure spéciale", "особая защита", "особую защиту"];
 
 	private bool isStandardArmorUsed;
 	private bool isHeavyArmorUsed;

--- a/Persistence/Json/Migrations/MigrationHandler.cs
+++ b/Persistence/Json/Migrations/MigrationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using static Persistence.Json.Migrations.IMigrationHandler;
 
 namespace Persistence.Json.Migrations;
@@ -25,10 +26,17 @@ public class MigrationHandler : IMigrationHandler
 		);
 
 		// Chain future migrations here
-		var final = jsonVersion.MigrateV2()
+		try
+		{
+			var final = jsonVersion.MigrateV2()
 			.MigrateV3()
 			.MigrateV4();
 
-		return final.Json.ToString();
+			return final.Json.ToString();
+		}
+		catch (JsonException ex)
+		{
+			throw new JsonException($"{ex.Message}{Environment.NewLine}{json}", ex);
+		}
 	}
 }

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Persistence.Json;
 using Persistence.Json.Migrations;
-using System.Text;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 using UI;
 using UI.Services;
@@ -45,7 +44,7 @@ jankyErrorProvider.Intercept += async exception =>
 {
 	var jSRuntime = host.Services.GetRequiredService<IJSRuntime>();
 
-	await jSRuntime.InvokeVoidAsync("bladesStackTrace", Encoding.UTF8.GetBytes($"{exception.Message}: {exception.StackTrace!}"));
+	await InterceptErrorProvider.SetErrorMessage(jSRuntime, exception);
 };
 
 await host.RunAsync();

--- a/UI/Services/InterceptErrorProvider.cs
+++ b/UI/Services/InterceptErrorProvider.cs
@@ -1,4 +1,7 @@
-﻿namespace UI.Services;
+﻿using Microsoft.JSInterop;
+using System.Text;
+
+namespace UI.Services;
 
 public sealed class InterceptErrorProvider() : ILoggerProvider
 {
@@ -18,6 +21,23 @@ public sealed class InterceptErrorProvider() : ILoggerProvider
 
 			errorProvider.Intercept?.Invoke(exception);
 		}
+	}
+
+	public static async Task SetErrorMessage(IJSRuntime jSRuntime, Exception exception)
+	{
+		StringBuilder message = new(exception.Message);
+		message.AppendLine(exception.StackTrace);
+		var inner = exception.InnerException;
+
+		while (inner != null)
+		{
+			message.AppendLine("INNER: ");
+			message.AppendLine(inner.Message);
+			message.AppendLine(inner.StackTrace);
+			inner = inner.InnerException;
+		}
+
+		await jSRuntime.InvokeVoidAsync("bladesStackTrace", Encoding.UTF8.GetBytes(message.ToString()));
 	}
 }
 

--- a/blades.sln
+++ b/blades.sln
@@ -7,7 +7,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7DEB315E-DB92-4620-A55C-9B4FEF38CF78}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		Dockerfile = Dockerfile
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Persistence", "Persistence\Persistence.csproj", "{5AA51F4C-927A-4A3B-9727-A26C90D990A3}"


### PR DESCRIPTION
When a migration fails, it'd be good to get a copy of the character sheet embedded in the error message. Interested in seeing a better way to do this moving forward, not sure what it is.

Tempted to use the OneOf library.